### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: Deploy to GitHub Pages
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/njvanas/njvanas.github.io/security/code-scanning/2](https://github.com/njvanas/njvanas.github.io/security/code-scanning/2)

To resolve the issue, add an explicit `permissions` block to the workflow. Since the workflow requires read access to repository contents and write access to GitHub Pages for deployment, the permissions block should specify `contents: read` and `pages: write`. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the tasks without granting excessive access.

The fix involves adding the permissions block at the root level of the workflow file (`.github/workflows/main.yml`), applying it to all jobs in the workflow that do not have their own `permissions` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
