### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main  # Trigger workflow when pushing to the main branch
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/njvanas/njvanas.github.io/security/code-scanning/1](https://github.com/njvanas/njvanas.github.io/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow at the root level or within the specific job (`build-and-push`). The permissions block should define the least privilege necessary for the workflow tasks. For this workflow:
- `contents: read` is required to read the repository contents during the checkout step.
- No other permissions are necessary since the workflow interacts with external services (e.g., Docker Hub) using secrets.

The permissions block will be added at the root level of the workflow to apply to all jobs uniformly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
