### PR TITLE
Add quick navigation links

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { slugify } from '../utils/slug';
 import { Briefcase, Calendar, MapPin } from 'lucide-react';
 
 interface ExperienceItem {
@@ -129,18 +130,31 @@ const Experience: React.FC = () => {
               Professional Experience
             </h2>
             <div className="w-24 h-1 bg-blue-500 mx-auto mb-8"></div>
-            <p className="text-xl text-gray-300 max-w-2xl mx-auto">
-              Over a decade of experience in cybersecurity and IT infrastructure across multiple continents.
-            </p>
-          </div>
+          <p className="text-xl text-gray-300 max-w-2xl mx-auto">
+            Over a decade of experience in cybersecurity and IT infrastructure across multiple continents.
+          </p>
+        </div>
 
-          {/* Timeline */}
+        {/* Quick Links */}
+        <div className="mb-8 flex flex-wrap gap-3 text-sm">
+          {experiences.map((exp, index) => (
+            <a
+              key={index}
+              href={`#${slugify(exp.title)}`}
+              className="text-blue-400 hover:underline"
+            >
+              {exp.company}
+            </a>
+          ))}
+        </div>
+
+        {/* Timeline */}
           <div className="relative">
             {/* Timeline Line */}
             <div className="absolute left-8 top-0 bottom-0 w-0.5 bg-blue-500/30 hidden md:block"></div>
 
             {experiences.map((exp, index) => (
-              <div key={index} className="relative mb-12 md:ml-16">
+              <div key={index} id={slugify(exp.title)} className="relative mb-12 md:ml-16">
                 {/* Timeline Dot */}
                 <div className="absolute -left-20 top-6 w-4 h-4 bg-blue-500 rounded-full border-4 border-slate-900 hidden md:block"></div>
                 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ExternalLink, Github, Code, Wrench, Globe, Zap, ChefHat, Download } from 'lucide-react';
 import { handleExternalLink } from '../utils/security';
+import { slugify } from '../utils/slug';
 
 interface Project {
   title: string;
@@ -113,19 +114,33 @@ const Projects: React.FC = () => {
               Featured Projects
             </h2>
             <div className="w-24 h-1 bg-blue-500 mx-auto mb-8"></div>
-            <p className="text-xl text-gray-300 max-w-2xl mx-auto">
-              A showcase of my technical projects demonstrating expertise in cybersecurity, 
-              automation, and modern web development.
-            </p>
-          </div>
+          <p className="text-xl text-gray-300 max-w-2xl mx-auto">
+            A showcase of my technical projects demonstrating expertise in cybersecurity,
+            automation, and modern web development.
+          </p>
+        </div>
 
-          {/* Projects Grid */}
+        {/* Quick Links */}
+        <div className="mb-8 flex flex-wrap gap-3 text-sm">
+          {projects.map((project, index) => (
+            <a
+              key={index}
+              href={`#${slugify(project.title)}`}
+              className="text-blue-400 hover:underline"
+            >
+              {project.title}
+            </a>
+          ))}
+        </div>
+
+        {/* Projects Grid */}
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {projects.map((project, index) => (
-              <div
-                key={index}
-                className="bg-slate-900/50 rounded-lg p-6 hover:bg-slate-900/70 transition-all duration-300 border border-slate-700/50 hover:border-blue-500/50 group"
-              >
+          {projects.map((project, index) => (
+            <div
+              key={index}
+              id={slugify(project.title)}
+              className="bg-slate-900/50 rounded-lg p-6 hover:bg-slate-900/70 transition-all duration-300 border border-slate-700/50 hover:border-blue-500/50 group"
+            >
                 {/* Project Icon & Category */}
                 <div className="flex items-center justify-between mb-4">
                   <div className="p-3 bg-blue-600/20 rounded-lg text-blue-400 group-hover:bg-blue-600/30 transition-colors duration-300">

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,6 @@
+export const slugify = (str: string): string => {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+};


### PR DESCRIPTION
## Summary
- add slugify utility
- link directly to experience entries and project cards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687642b3d248832c8e603041cd10037b